### PR TITLE
fix: resolve atuin installation and initialization on Linux

### DIFF
--- a/dot_config/zsh/dot_zshrc.tmpl
+++ b/dot_config/zsh/dot_zshrc.tmpl
@@ -80,18 +80,25 @@ fi
 if command -v atuin >/dev/null; then
   # Similar logic for atuin - immediate load in sessions, lazy load in main shell
   if [[ -n "$TMUX" ]] || [[ -n "$ZELLIJ" && "$ZELLIJ" != "0" ]] || [[ "${SHLVL:-1}" -gt 2 ]]; then
-    eval "$(atuin init zsh)"
+    eval "$(atuin init zsh)" 2>/dev/null || {
+      [[ -n "$ZSHRC_DEBUG" ]] && echo "Warning: atuin init failed"
+    }
   else
     # Lazy loading for performance
     _lazy_atuin() {
       unfunction _lazy_atuin
-      eval "$(atuin init zsh)"
+      eval "$(atuin init zsh)" 2>/dev/null || {
+        echo "Warning: atuin initialization failed"
+        return 1
+      }
       # Re-bind the key after initialization
       [[ -n "$1" ]] && zle "$1"
     }
     zle -N _lazy_atuin
     bindkey '^r' _lazy_atuin
   fi
+else
+  [[ -n "$ZSHRC_DEBUG" ]] && echo "atuin not found - using default ^r binding"
 fi
 
 # Starship prompt - load immediately for visual feedback

--- a/packages/apt.txt
+++ b/packages/apt.txt
@@ -12,3 +12,4 @@ bat
 exa
 neovim
 jq
+# Note: atuin is not available in Ubuntu repos, install via cargo or binary

--- a/packages/dnf.txt
+++ b/packages/dnf.txt
@@ -11,3 +11,4 @@ fzf
 bat
 neovim
 jq
+# Note: atuin is not available in Fedora repos, install via cargo or binary

--- a/packages/pacman.txt
+++ b/packages/pacman.txt
@@ -12,3 +12,4 @@ bat
 exa
 neovim
 jq
+atuin

--- a/run_once_before_install-packages.sh.tmpl
+++ b/run_once_before_install-packages.sh.tmpl
@@ -32,6 +32,35 @@ brew bundle --file="{{ .chezmoi.sourceDir }}/homebrew/{{ if .business_use }}Brew
 
 {{- else if eq .chezmoi.os "linux" }}
 # Linux: Use native package managers (no Homebrew)
+
+# Function to install atuin on Linux (not available in most repos)
+install_atuin_linux() {
+    if command -v atuin >/dev/null 2>&1; then
+        echo "atuin is already installed"
+        return 0
+    fi
+    
+    echo "Installing atuin via precompiled binary..."
+    
+    # Create temporary directory
+    local temp_dir=$(mktemp -d)
+    cd "$temp_dir"
+    
+    # Download and install atuin
+    curl -LsSf https://setup.atuin.sh | sh || {
+        echo "Warning: Failed to install atuin via setup script"
+        # Fallback: try to install via cargo if available
+        if command -v cargo >/dev/null 2>&1; then
+            echo "Attempting to install atuin via cargo..."
+            cargo install atuin || echo "Warning: Failed to install atuin via cargo"
+        fi
+    }
+    
+    # Cleanup
+    cd - >/dev/null
+    rm -rf "$temp_dir"
+}
+
 if command -v apt >/dev/null 2>&1; then
     echo "Using apt package manager..."
     sudo apt update
@@ -44,6 +73,9 @@ if command -v apt >/dev/null 2>&1; then
         echo "Installing: $package"
         sudo apt install -y "$package" || echo "Warning: Failed to install $package"
     done < "{{ .chezmoi.sourceDir }}/packages/apt.txt"
+    
+    # Install atuin separately (not available in apt repos)
+    install_atuin_linux
 
 elif command -v dnf >/dev/null 2>&1; then
     echo "Using dnf package manager..."
@@ -56,6 +88,9 @@ elif command -v dnf >/dev/null 2>&1; then
         echo "Installing: $package"
         sudo dnf install -y "$package" || echo "Warning: Failed to install $package"
     done < "{{ .chezmoi.sourceDir }}/packages/dnf.txt"
+    
+    # Install atuin separately (not available in dnf repos)
+    install_atuin_linux
 
 elif command -v pacman >/dev/null 2>&1; then
     echo "Using pacman package manager..."


### PR DESCRIPTION
Added proper atuin support for Linux environments:

Package Management:
- Added atuin to pacman.txt (available in AUR)
- Added notes about atuin unavailability in apt/dnf repos
- Created install_atuin_linux() function for binary installation

Installation Improvements:
- Uses official atuin installer (setup.atuin.sh)
- Fallback to cargo installation if available
- Proper error handling and cleanup

zsh Configuration:
- Added error handling for atuin init failures
- Debug messages when atuin is not found
- Graceful fallback to default ^r binding

This resolves atuin not being available on Linux systems.

🤖 Generated with [Claude Code](https://claude.ai/code)