### PR TITLE
fix: add OS-specific git credential helper configuration

### DIFF
--- a/dot_config/git/main.tmpl
+++ b/dot_config/git/main.tmpl
@@ -27,7 +27,12 @@
 	rebase = false
 [merge]
 	conflictstype = diff3
+{{- if eq .chezmoi.os "darwin" }}
 [credential]
 	helper = osxkeychain
+{{- else if eq .chezmoi.os "linux" }}
+[credential]
+	helper = store
+{{- end }}
 [include]
 	path = ~/.config/git/secrets


### PR DESCRIPTION
Convert git/main to template file to handle credential helpers based on OS:
- macOS: uses osxkeychain (existing behavior)
- Linux: uses store (file-based credential storage)

This fixes the "git: 'credential-osxkeychain' is not a git command" error on Linux systems when running go mod tidy or other git operations.

Fixes #47

🤖 Generated with [Claude Code](https://claude.ai/code)