### PR TITLE
feat: Switch locale configuration to Japanese (ja_JP.UTF-8)

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -14,8 +14,10 @@ export EDITOR="nvim"
 export VISUAL="nvim"
 
 # Language and locale
-export LANG="en_US.UTF-8"
-export LC_ALL="en_US.UTF-8"
+export LANG="ja_JP.UTF-8"
+export LC_ALL="ja_JP.UTF-8"
+export LC_CTYPE="ja_JP.UTF-8"
+export LC_MESSAGES="ja_JP.UTF-8"
 
 {{- if eq .chezmoi.os "darwin" }}
 # macOS specific


### PR DESCRIPTION
## Summary
- Changed locale configuration from English (en_US.UTF-8) to Japanese (ja_JP.UTF-8)
- Added explicit LC_CTYPE and LC_MESSAGES settings for better Japanese language support
- Fixes the bash warning: "setlocale: LC_ALL: cannot change locale (en_US.UTF-8)"

## Changes
- Modified `dot_zshenv.tmpl` to set Japanese locale as primary
- Set LANG="ja_JP.UTF-8"
- Set LC_ALL="ja_JP.UTF-8"
- Added LC_CTYPE="ja_JP.UTF-8" for character type handling
- Added LC_MESSAGES="ja_JP.UTF-8" for system messages

## Test plan
- [x] Apply changes with `chezmoi apply ~/.zshenv`
- [ ] Start new shell session to verify locale settings
- [ ] Confirm no locale warnings appear
- [ ] Verify Japanese text displays correctly in terminal

🤖 Generated with [Claude Code](https://claude.ai/code)