### PR TITLE
feat: enhance Linux package management and locale configuration

### DIFF
--- a/dot_config/zsh/modules/terminal.zsh
+++ b/dot_config/zsh/modules/terminal.zsh
@@ -47,5 +47,5 @@ safe_tput() {
   fi
 }
 
-# Export the function for use in other scripts
-export -f safe_tput 2>/dev/null || true
+# Export the function for use in other scripts (suppress output)
+{ export -f safe_tput } 2>/dev/null || true

--- a/packages/apt.txt
+++ b/packages/apt.txt
@@ -5,9 +5,10 @@ wget
 git
 zsh
 tmux
+build-essential
+locales
 fd-find
 ripgrep
-fzf
 bat
 jq
 unzip

--- a/packages/dnf.txt
+++ b/packages/dnf.txt
@@ -7,7 +7,6 @@ zsh
 tmux
 fd-find
 ripgrep
-fzf
 bat
 unzip
 # neovim is installed via dedicated script for latest version

--- a/packages/pacman.txt
+++ b/packages/pacman.txt
@@ -7,7 +7,6 @@ zsh
 tmux
 fd
 ripgrep
-fzf
 bat
 jq
 atuin

--- a/run_once_before_install-packages.sh.tmpl
+++ b/run_once_before_install-packages.sh.tmpl
@@ -94,6 +94,18 @@ if command -v apt >/dev/null 2>&1; then
     echo "Using apt package manager..."
     sudo apt update
 
+    # Configure locale to fix ja_JP.UTF-8 warnings
+    echo "Configuring Japanese locale..."
+    if ! locale -a | grep -q "ja_JP.utf8"; then
+        # Enable Japanese locale in /etc/locale.gen
+        sudo sed -i 's/^# ja_JP.UTF-8 UTF-8/ja_JP.UTF-8 UTF-8/' /etc/locale.gen 2>/dev/null || true
+        # Generate locales
+        sudo locale-gen 2>/dev/null || true
+        echo "Japanese locale configured"
+    else
+        echo "Japanese locale already available"
+    fi
+
     # Install packages from apt.txt
     echo "Installing packages from apt.txt..."
     while IFS= read -r package || [[ -n "$package" ]]; do
@@ -157,6 +169,22 @@ if [[ -f "{{ .chezmoi.sourceDir }}/scripts/install-neovim-latest.sh" ]]; then
     }
 else
     echo "Warning: NeoVim installation script not found"
+fi
+
+# Install latest fzf on Linux
+echo "=== Installing latest fzf ==="
+echo "Installing fzf from GitHub releases..."
+FZF_VERSION=$(curl -s "https://api.github.com/repos/junegunn/fzf/releases/latest" | grep -Po '"tag_name": "v\K[^"]*' || echo "0.56.3")
+FZF_URL="https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz"
+
+if curl -fsSL "$FZF_URL" | sudo tar -xz -C /usr/local/bin fzf; then
+    echo "✓ fzf v${FZF_VERSION} installed to /usr/local/bin/fzf"
+    # Ensure /usr/local/bin/fzf takes precedence over system package
+    if command -v update-alternatives >/dev/null 2>&1; then
+        sudo update-alternatives --install /usr/bin/fzf fzf /usr/local/bin/fzf 100 2>/dev/null || true
+    fi
+else
+    echo "Warning: fzf installation failed, falling back to system package if available"
 fi
 
 # Install special tools on Linux using unified installer


### PR DESCRIPTION
## Summary
- Fix terminal.zsh export function to suppress error output properly  
- Add build-essential and locales packages to apt.txt for better development environment
- Remove fzf from package managers, install latest version from GitHub releases instead
- Add Japanese locale configuration to fix ja_JP.UTF-8 warnings on Linux systems
- Improve fzf installation with proper binary placement and alternatives setup

## Test plan
- [ ] Test terminal.zsh changes don't produce error output
- [ ] Validate new packages install correctly on Linux systems
- [ ] Confirm fzf installs latest version from GitHub releases
- [ ] Check Japanese locale configuration resolves UTF-8 warnings

🤖 Generated with [Claude Code](https://claude.ai/code)