### PR TITLE
Fix missing log functions in .zprofile

### DIFF
--- a/dot_config/zsh/dot_zprofile.tmpl
+++ b/dot_config/zsh/dot_zprofile.tmpl
@@ -13,13 +13,12 @@ function load() {
 
 # Load essential modules
 load "$ZMODDIR/platform.zsh"
-load "$ZMODDIR/logging.zsh"
 
 {{- if eq .chezmoi.os "darwin" }}
 # macOS: 1Password CLI integration (conditional)
 if [[ ! -d "$XDG_CONFIG_HOME/op/plugins" ]]; then
-  log_warn "1password plugins is not installed"
-  log_info "Run 'op plugin init gh' to install 1password plugins"
+  echo "Warning: 1password plugins is not installed" >&2
+  echo "Info: Run 'op plugin init gh' to install 1password plugins" >&2
 fi
 
 # Load 1Password plugins if available


### PR DESCRIPTION
## Summary
- Remove non-existent `logging.zsh` module load from `.zprofile`
- Replace `log_warn` and `log_info` function calls with standard `echo` statements to stderr
- Resolves "command not found" errors when starting login shells (`exec $SHELL -l`)

## Root Cause
The `.zprofile` template was trying to load `$ZMODDIR/logging.zsh` which doesn't exist in the current module structure. The logging functions `log_warn` and `log_info` were never defined, causing command not found errors.

## Test Plan
- [x] Verify `exec $SHELL -l` no longer produces errors
- [x] Confirm 1Password plugin warnings still display correctly
- [x] Test login shell initialization works properly

🤖 Generated with [Claude Code](https://claude.ai/code)